### PR TITLE
Solve missing add-apt-repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:bionic
 RUN apt-get update && apt-get install lzip git make sudo -y
+RUN sudo apt-get install software-properties-common -y
 RUN sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 RUN sudo apt-get update
 RUN sudo apt-get install gcc-6 g++-6 python3 python3-pip -y


### PR DESCRIPTION
Building this dockerfile it's impossibile to me (i think also everywhere) because it calls add-apt-repository but it doesn't have it installed. In order to solve this, it is enough to install software-properties-common.

P.S. Congrats for the awesome project, hope this may help