### PR TITLE
WIP - Rpi on docker doesn't work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,22 @@
-FROM ubuntu:bionic
-RUN apt-get update && apt-get install lzip git make sudo -y
+FROM ubuntu:focal
+RUN apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" \
+    apt-get -y install tzdata \
+    apt-utils \
+    git \
+    make \
+    sudo
 RUN sudo apt-get install software-properties-common -y
 RUN sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 RUN sudo apt-get update
-RUN sudo apt-get install build-essential libssl-dev libpython3-all-dev gcc-6 g++-6 python3 python3-pip zlib1g-dev -y
+RUN sudo apt-get install -y build-essential \
+    libssl-dev \
+    libpython3-all-dev \
+    gcc \
+    g++ \
+    python3 \
+    python3-pip \
+    zlib1g-dev
 RUN pip3 install Cython
 COPY . Pyfhel
 # RUN git clone --recursive https://github.com/AlbertoPimpo/Pyfhel.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ RUN apt-get update && apt-get install lzip git make sudo -y
 RUN sudo apt-get install software-properties-common -y
 RUN sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 RUN sudo apt-get update
-RUN sudo apt-get install gcc-6 g++-6 python3 python3-pip -y
+RUN sudo apt-get install build-essential libssl-dev libpython3-all-dev gcc-6 g++-6 python3 python3-pip zlib1g-dev -y
+RUN pip3 install Cython
 RUN git clone --recursive https://github.com/ibarrond/Pyfhel
-RUN cd Pyfhel && pip3 install .
+WORKDIR "./Pyfhel"
+RUN pip3 install .

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ RUN sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 RUN sudo apt-get update
 RUN sudo apt-get install build-essential libssl-dev libpython3-all-dev gcc-6 g++-6 python3 python3-pip zlib1g-dev -y
 RUN pip3 install Cython
-RUN git clone --recursive https://github.com/ibarrond/Pyfhel
+COPY . Pyfhel
+# RUN git clone --recursive https://github.com/AlbertoPimpo/Pyfhel.git
 WORKDIR "./Pyfhel"
+RUN git submodule update --init --recursive
 RUN pip3 install .

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,9 @@ elif platform.system() == 'Darwin': # MacOS
 else:  # Linux, GCC
     extra_compile_flags += ["-std=c++17","-O3"]
 
+    machine_arch = os.uname()[-1]
+    if machine_arch == 'aarch64' or machine_arch.startswith('arm'):
+        extra_compile_flags += ["-DSEAL_BUILD_SEAL_C=1", "-DSEAL_USE_INTRIN=0"]
 
 # --------------------------- LIBRARY COMPILATION ------------------------------
 # Here we compile Afhel (with the backends) and bundle it into a static library


### PR DESCRIPTION
I tried to follow steps that @andrew-ma said to us, i pulled his commit, i added the packages that are needed (it seems also that Cython has to be installed separately) but I have still errors. I also updated the dockerfile with WORKDIR syntax instead of RUN cd .

Tests are done on rpi 3b+ raspian latest (32 bit).

>Step 10/10 : RUN pip3 install .
 ---> Running in 8159bd28d8a3
Processing /Pyfhel
Requirement already satisfied: cython>=0.29.2 in /usr/local/lib/python3.6/dist-packages (from Pyfhel==2.2.5)
Collecting numpy>=1.16.0 (from Pyfhel==2.2.5)
  Downloading https://files.pythonhosted.org/packages/c5/63/a48648ebc57711348420670bb074998f79828291f68aebfff1642be212ec/numpy-1.19.4.zip (7.3MB)
Collecting setuptools>=45.0.0 (from Pyfhel==2.2.5)
  Downloading https://files.pythonhosted.org/packages/6d/38/c21ef5034684ffc0412deefbb07d66678332290c14bb5269c85145fbd55e/setuptools-50.3.2-py3-none-any.whl (785kB)
Building wheels for collected packages: numpy
  Running setup.py bdist_wheel for numpy: started
  Running setup.py bdist_wheel for numpy: still running...
  Running setup.py bdist_wheel for numpy: still running...
  Running setup.py bdist_wheel for numpy: still running...
  Running setup.py bdist_wheel for numpy: still running...
  Running setup.py bdist_wheel for numpy: still running...
  Running setup.py bdist_wheel for numpy: still running...
  Running setup.py bdist_wheel for numpy: still running...
  Running setup.py bdist_wheel for numpy: still running...
  Running setup.py bdist_wheel for numpy: still running...
  Running setup.py bdist_wheel for numpy: finished with status 'done'
  Stored in directory: /root/.cache/pip/wheels/b1/d6/2f/b576b6c983652fa9c02be4c2a4c3896e9540c3b5dc85439986
Successfully built numpy
Installing collected packages: numpy, setuptools, Pyfhel
  Found existing installation: setuptools 39.0.1
    Not uninstalling setuptools at /usr/lib/python3/dist-packages, outside environment /usr
  Running setup.py install for Pyfhel: started
    Running setup.py install for Pyfhel: finished with status 'error'
    Complete output from command /usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-tjiqw7tw-build/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-w0md3bfy-record/install-record.txt --single-version-externally-managed --compile:
    running install
    running build
    running build_py
    creating build
    creating build/lib.linux-armv7l-3.6
    creating build/lib.linux-armv7l-3.6/Pyfhel
    copying Pyfhel/__init__.py -> build/lib.linux-armv7l-3.6/Pyfhel
    copying Pyfhel/test.py -> build/lib.linux-armv7l-3.6/Pyfhel
    creating build/lib.linux-armv7l-3.6/Pyfhel/util
    copying Pyfhel/util/ENCODING_t.py -> build/lib.linux-armv7l-3.6/Pyfhel/util
    copying Pyfhel/util/__init__.py -> build/lib.linux-armv7l-3.6/Pyfhel/util
    running build_clib
    building 'Afhel' library
    creating build/temp.linux-armv7l-3.6
    creating build/temp.linux-armv7l-3.6/Pyfhel
    creating build/temp.linux-armv7l-3.6/Pyfhel/Afhel
    creating build/temp.linux-armv7l-3.6/Pyfhel/SEAL
    creating build/temp.linux-armv7l-3.6/Pyfhel/SEAL/SEAL
    creating build/temp.linux-armv7l-3.6/Pyfhel/SEAL/SEAL/seal
    arm-linux-gnueabihf-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -I/usr/include/python3.6m -IPyfhel -IPyfhel/Afhel -IPyfhel/SEAL/SEAL/seal -c Pyfhel/Afhel/Afseal.cpp -o build/temp.linux-armv7l-3.6/Pyfhel/Afhel/Afseal.o -DHAVE_CONFIG_H -std=c++17 -O3
    In file included from Pyfhel/Afhel/../SEAL/SEAL/seal/defines.h:68:0,
                     from Pyfhel/Afhel/../SEAL/SEAL/seal/bigpoly.h:8,
                     from Pyfhel/Afhel/../SEAL/SEAL/seal/seal.h:3,
                     from Pyfhel/Afhel/Afseal.h:41,
                     from Pyfhel/Afhel/Afseal.cpp:37:
    Pyfhel/Afhel/../SEAL/SEAL/seal/gcc.h:20:10: fatal error: x86intrin.h: No such file or directory
     #include <x86intrin.h>
              ^~~~~~~~~~~~~
    compilation terminated.
    error: command 'arm-linux-gnueabihf-gcc' failed with exit status 1
>
>    ----------------------------------------
> Command "/usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-tjiqw7tw-build/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-w0md3bfy-record/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-tjiqw7tw-build/
The command '/bin/sh -c pip3 install .' returned a non-zero code: 1