### PR TITLE
update PALISADE submodule to gitlab url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/shaih/helib
 [submodule "PALISADE"]
 	path = Pyfhel/PALISADE
-	url = https://git.njit.edu/palisade/PALISADE
+	url = https://gitlab.com/palisade/palisade-release
 
 [submodule "SEAL"]
 	path = Pyfhel/SEAL


### PR DESCRIPTION
According to (what I believe to be) the PALISADE [website](https://palisade-crypto.org/software-library/), the codebase is now hosted on Gitlab. I've updated the broken module ref.

Fixes #119 