### PR TITLE
Fix various build issues

### DIFF
--- a/Pyfhel/PyPoly.pyx
+++ b/Pyfhel/PyPoly.pyx
@@ -83,7 +83,7 @@ cdef class PyPoly:
     
     @_scheme.setter
     def _scheme(self, new_scheme):
-        if not isinstance(new_scheme, scheme_t):
+        if not isinstance(new_scheme, Scheme_t):
             raise TypeError("<Pyfhel ERROR> Scheme type of PyPoly must be scheme_t")        
         self._scheme = new_scheme
         

--- a/Pyfhel/__init__.py
+++ b/Pyfhel/__init__.py
@@ -7,4 +7,4 @@ __all__    = ["Pyfhel", "PyCtxt", "PyPtxt", "PyPoly"]
 __name__   = "Pyfhel"
 __author__ = "Alberto Ibarrondo"
 
-__version__ = "3.4.2"
+__version__ = "3.4.3"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Python library for Addition, Subtraction, Multiplication and Scalar Product over
 |--------------------------------------------|--------------------------------------------------------------------------------------------|
 | :flags: **Language**                       | Python (3.7+), with Cython and C++ (:warning: _requires a [C++17 compiler][3]_ :warning:.) |
 | :computer: **OS**                          | Linux, Windows & MacOS.                                                                    |
-| :1234: **Version** | 3.4.2 (stable)                                                                                                     |
+| :1234: **Version** | 3.4.3 (stable)                                                                                                     |
 | :books: **Docs**                           | In [readthedocs][1]!                                                                       |
 | :pencil2: **Demos/Examples**               | [In the docs][4] with the outputs, sources in the [`examples`][2] folder.                  |
 | :electric_plug: **Backends**               | [SEAL][5], [OpenFHE (WIP)][6]. Shipped alongside Pyfhel.                                   |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@
 # Pyfhel's core metadata
 [project]
 name = "Pyfhel"
-version = "3.4.2"
+version = "3.4.3"
 description = "Python for Homomorphic Encryption Libraries"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
@@ -38,7 +40,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "numpy>=1.21"
+  "numpy>=1.26"
 ]
 
 [project.optional-dependencies]
@@ -57,10 +59,10 @@ repository = "https://github.com/ibarrond/github"
 # Minimum requirements for the build system to execute.
 [build-system]
 requires = [
-  "setuptools<=60.9",
+  "setuptools>=64",
   "wheel",
   "cython>=3.0.0",
-  "numpy>=1.21",
+  "numpy>=1.26",
   "cmake>=3.15",
   "toml>=0.10"
 ]


### PR DESCRIPTION
Modern setups (e.g., ubuntu 24.04) weren't able to build Pyfhel successfully anymore because of a few issues
* the SEAL version we used had a dependency asking for cmake <3.5 compatibility which modern cmake no longer supports -> updated to most recent SEAL version
* Python3.12 deprecated a few things and we had numpy/setuptools dependencies that were still using them -> bump numpy/setuptools version
* There was also a minor bug in PyPoly.pyx - no idea why that hadn't popped up earlier, as it shouldn't have worked even on older setups... 

This should fix #257, #256